### PR TITLE
Show all items and make children expandable in left sidebar

### DIFF
--- a/sphinx_symbiflow_theme/__init__.py
+++ b/sphinx_symbiflow_theme/__init__.py
@@ -155,12 +155,15 @@ def html_theme_path():
     return [os.path.dirname(os.path.abspath(__file__))]
 
 
-def ul_to_list(node: bs4.element.Tag, fix_root: bool, page_name: str) -> List[dict]:
+def ul_to_list(node: bs4.element.Tag, fix_root: bool, page_name: str,
+               parent_id: str) -> List[dict]:
     out = []
+    idx = 0
     for child in node.find_all("li", recursive=False):
         if callable(child.isspace) and child.isspace():
             continue
         formatted = {}
+        formatted["nested"] = False
         if child.a is not None:
             formatted["href"] = child.a["href"]
             formatted["contents"] = "".join(map(str, child.a.contents))
@@ -169,10 +172,14 @@ def ul_to_list(node: bs4.element.Tag, fix_root: bool, page_name: str) -> List[di
                 formatted["href"] = "#" + slug
             formatted["current"] = "current" in child.a.get("class", [])
         if child.ul is not None:
-            formatted["children"] = ul_to_list(child.ul, fix_root, page_name)
+            formatted["nested"] = True
+            formatted["id"] = "{}-{}".format(parent_id, idx)
+            formatted["children"] = ul_to_list(child.ul, fix_root, page_name,
+                                               formatted["id"])
         else:
             formatted["children"] = []
         out.append(formatted)
+        idx += 1
     return out
 
 
@@ -198,15 +205,17 @@ def derender_toc(
     nodes = []
     try:
         toc = BeautifulSoup(toc_text, features="html.parser")
+        idx = 0
         for child in toc.children:
             if callable(child.isspace) and child.isspace():
                 continue
             if child.name == "p":
                 nodes.append({"caption": "".join(map(str, child.contents))})
             elif child.name == "ul":
-                nodes.extend(ul_to_list(child, fix_root, page_name))
+                nodes.extend(ul_to_list(child, fix_root, page_name, idx))
             else:
                 raise NotImplementedError
+            idx += 1
     except Exception as exc:
         logger = logging.getLogger(__name__)
         logger.warning(

--- a/sphinx_symbiflow_theme/sphinx_symbiflow_theme/globaltoc.html
+++ b/sphinx_symbiflow_theme/sphinx_symbiflow_theme/globaltoc.html
@@ -6,19 +6,22 @@
   {% if "caption" in item %}
     <span class="md-nav__link caption">{{ item.caption }}</span>
   {% else %}
-  {% if item.current %}
-  <input class="md-toggle md-nav__toggle" data-md-toggle="toc" type="checkbox" id="__toc">
-  <label class="md-nav__link md-nav__link--active" for="__toc"> {{ item.contents }} </label>
-  {% endif %}
-    <a href="{{ item.href|e }}" class="md-nav__link{% if item.current %} md-nav__link--active{% endif %}">{{ item.contents }}</a>
-    {% if item.current %}
-      {%- set sphinx_symbiflow_theme_include_searchbox=False %}
-      {% include "localtoc.html" %}
+    {%- set sphinx_symbiflow_theme_include_searchbox=False %}
+    {%- if item.nested -%}
+      <input class="md-toggle md-nav__toggle" data-md-toggle="toc-{{ item.id }}" type="checkbox" id="__toc-{{ item.id }}">
+      <label class="md-nav__link md-nav__link--nested" for="__toc-{{ item.id }}"> {{ item.contents }}
+        <span class="md-nav__icon"><span class="md-icon"></span></span></label>
+      {%- if item.children -%}
+        <nav class="md-nav">
+          <ul class="md-nav__list">{{ loop(item.children) }}</ul>
+        </nav>
+      {%- endif %}
+    {% else %}
+      <a href="{{ item.href|e }}" class="md-nav__link{% if item.current %} md-nav__link--active{% endif %}">
+        {{ item.contents }}</a>
     {% endif %}
     {%- set sphinx_symbiflow_theme_include_searchbox=True %}
-    {%- if item.children -%}
-      <ul class="md-nav__list"> {{ loop(item.children) }}</ul>
-    {%- endif %}
+
   {% endif %}
   </li>
 {%- endfor %}

--- a/sphinx_symbiflow_theme/sphinx_symbiflow_theme/static/stylesheets/application.css
+++ b/sphinx_symbiflow_theme/sphinx_symbiflow_theme/static/stylesheets/application.css
@@ -869,9 +869,6 @@ html .md-footer-meta.md-typeset a:focus,html .md-footer-meta.md-typeset a:hover{
 .md-nav__item--nested>.md-nav__link:after{
     content:"\E313"
 }
-html .md-nav__link[for=__toc],html .md-nav__link[for=__toc]+.md-nav__link:after,html .md-nav__link[for=__toc]~.md-nav{
-    display:none
-}
 .md-nav__link[data-md-state=blur]{
     color:rgba(0,0,0,.54)
 }
@@ -2222,9 +2219,6 @@ html .md-typeset .superfences-tabs>label:hover{
         color:inherit;
         content:"\E8DE"
     }
-    html .md-nav__link[for=__toc]+.md-nav__link{
-        display:none
-    }
     html .md-nav__link[for=__toc]~.md-nav{
         display:flex
     }
@@ -2753,6 +2747,22 @@ html .md-typeset .superfences-tabs>label:hover{
     }
     .no-js .md-nav[data-md-state=expand],.no-js .md-nav__toggle:checked~.md-nav{
         display:block
+    }
+    .md-nav__icon {
+        float: right;
+    }
+    .md-nav__icon .md-icon {
+        display: inline-block;
+        transition: transform 250ms;
+    }
+    .md-nav__icon .md-icon:before {
+        content: "\e409";
+        vertical-align: -0.15rem;
+    }
+    .md-nav__toggle:checked~.md-nav__link .md-icon,
+    .md-nav__toggle:indeterminate~.md-nav__link .md-icon
+    {
+        transform: rotate(90deg);
     }
     .md-nav__item--nested>.md-nav>.md-nav__title{
         display:none

--- a/sphinx_symbiflow_theme/sphinx_symbiflow_theme/theme.conf
+++ b/sphinx_symbiflow_theme/sphinx_symbiflow_theme/theme.conf
@@ -45,7 +45,7 @@ base_url =
 # The maximum depth of the global TOC; set it to -1 to allow unlimited depth
 globaltoc_depth = 1
 # If true, TOC entries that are not ancestors of the current page are collapsed
-globaltoc_collapse = true
+globaltoc_collapse = false
 # If true, the global TOC tree will also contain hidden entries
 globaltoc_includehidden = true
 


### PR DESCRIPTION
In the upstream theme, the toc on the left side cannot be expanded. This patch adds all items to the toc and allows them to be expandable like in the old theme.

Before:

![image](https://user-images.githubusercontent.com/8130120/115139697-e475d280-a065-11eb-8b1c-5d87071727aa.png)

After:

![image](https://user-images.githubusercontent.com/8130120/115139690-dcb62e00-a065-11eb-82d1-4f612eb4d144.png)
