### PR TITLE
layout: add block 'extrasocial'

### DIFF
--- a/sphinx_symbiflow_theme/sphinx_symbiflow_theme/layout.html
+++ b/sphinx_symbiflow_theme/sphinx_symbiflow_theme/layout.html
@@ -159,6 +159,7 @@
     <div class="md-footer-meta md-typeset">
       <div class="md-footer-meta__inner md-grid">
         <div class="md-footer-social">
+          {%- block extrasocial %}
           {% if not theme_hide_symbiflow_links|tobool %}
             <div class="md-footer-social__link">
               <a href="https://symbiflow.github.io/" target="_blank">SymbiFlow</a>
@@ -174,6 +175,7 @@
             </div>
             </ul>
           {%- endif %}
+          {%- endblock %}
 
           {%- if theme_github_url %}
             <div class="md-footer-social__link">


### PR DESCRIPTION
This PR adds an `extrasocial` block to allow overriding the links in the footer, similarly to the ones in the header (https://github.com/SymbiFlow/sphinx_symbiflow_theme/blob/master/sphinx_symbiflow_theme/sphinx_symbiflow_theme/relbar.html#L19).